### PR TITLE
Improve compatiblity of capabilities parsing

### DIFF
--- a/bgp/fsm.go
+++ b/bgp/fsm.go
@@ -282,12 +282,16 @@ func (f *fsm) sendOpen(c net.Conn, transportAFI uint16) error {
 }
 
 func openCapabilities(o *bgp.BGPOpen) ([]bgp.ParameterCapabilityInterface, error) {
+	var caps []bgp.ParameterCapabilityInterface
 	for _, p := range o.OptParams {
 		if c, ok := p.(*bgp.OptionParameterCapability); ok {
-			return c.Capability, nil
+			caps = append(caps, c.Capability...)
 		}
 	}
-	return nil, errors.New("missing capabilities")
+	if len(caps) == 0 {
+		return nil, errors.New("missing capabilities")
+	}
+	return caps, nil
 }
 
 // validateOpen checks the OPEN message received from the peer. It returns an

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/msiegen/tinybgp
 go 1.21
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/jpillora/backoff v1.0.0
 	github.com/osrg/gobgp/v3 v3.20.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/osrg/gobgp/v3 v3.20.0 h1:U0dhaAo0QHscQQ+vTrnX2Rak9vaKnJ3aQDM5mAEeIEw=


### PR DESCRIPTION
Some Juniper devices send an OPEN message that has each capability individually wrapped in its own optional parameter message.