### PR TITLE
Record the source port of dynamic peers

### DIFF
--- a/bgp/addrconv.go
+++ b/bgp/addrconv.go
@@ -19,12 +19,13 @@ import (
 	"net/netip"
 )
 
-func addrFromNetAddr(addr net.Addr) netip.Addr {
+// addrFromNetAddr extracts the IP and port from a *net.TCPAddr.
+func addrFromNetAddr(addr net.Addr) (netip.Addr, int) {
 	switch a := addr.(type) {
 	case *net.TCPAddr:
 		aa, _ := netip.AddrFromSlice(a.IP)
-		return aa
+		return aa, a.Port
 	default:
-		return netip.Addr{}
+		return netip.Addr{}, 0
 	}
 }

--- a/bgp/server.go
+++ b/bgp/server.go
@@ -111,8 +111,8 @@ func (s *Server) removeDynamicPeer(p *Peer) {
 }
 
 func (s *Server) matchPeer(conn net.Conn) (*Peer, error) {
-	localAddr := addrFromNetAddr(conn.LocalAddr())
-	remoteAddr := addrFromNetAddr(conn.RemoteAddr())
+	localAddr, _ := addrFromNetAddr(conn.LocalAddr())
+	remoteAddr, remotePort := addrFromNetAddr(conn.RemoteAddr())
 	if !localAddr.IsValid() || !remoteAddr.IsValid() {
 		return nil, errors.New("unsupported peer address type")
 	}
@@ -151,6 +151,7 @@ func (s *Server) matchPeer(conn net.Conn) (*Peer, error) {
 		return nil, err
 	}
 	p.Addr = remoteAddr
+	p.Port = remotePort
 	p.Passive = true
 	p.LocalAddr = localAddr
 	p.dynamic = true


### PR DESCRIPTION
This does not change any behavior but makes some log messages more meaningful.