### PR TITLE
Add experimental support for extended communities

### DIFF
--- a/bgp/community.go
+++ b/bgp/community.go
@@ -64,3 +64,81 @@ func (c Community) Uint32() uint32 {
 func (c Community) String() string {
 	return fmt.Sprintf("%v:%v", c.Origin, c.Value)
 }
+
+// ExtendedCommunity BGP Extended Community as defined in
+// https://datatracker.ietf.org/doc/html/rfc4360.
+//
+// NOTE: Support for extended communities is experimental and subject to change.
+// Extended communities are not widely used on the internet and several details
+// of this implementation were determined empirically from a handful of routes.
+// If you need this and are able to contribute either code or expertise, please
+// open an issue on GitHub.
+type ExtendedCommunity uint64
+
+func newExtendedCommunity(b []byte) (ExtendedCommunity, error) {
+	if len(b) != 8 {
+		return 0, fmt.Errorf("invalid length for extended community: got %v, want 8", len(b))
+	}
+	c := uint64(b[0])<<56 |
+		uint64(b[1])<<48 |
+		uint64(b[2])<<40 |
+		uint64(b[3])<<32 |
+		uint64(b[4])<<24 |
+		uint64(b[5])<<16 |
+		uint64(b[6])<<8 |
+		uint64(b[7])
+	return ExtendedCommunity(c), nil
+}
+
+// type_ returns the high-order octet of the type field.
+func (c ExtendedCommunity) type_() uint8 {
+	return uint8(c >> 56) // & 0xff
+}
+
+// subType returns the low-order octet of the type field.
+func (c ExtendedCommunity) subType() uint8 {
+	return uint8(c >> 48) // & 0xff
+}
+
+// global returns the global administrator sub-field. It may be 2 bytes or
+// 4 bytes depending on the value in the type field. If the length cannot be
+// determined, a value of zero is returned.
+func (c ExtendedCommunity) global() uint32 {
+	switch c.type_() {
+	case 0x00, 0x40:
+		return uint32(c>>32) & 0xffff
+	case 0x01, 0x02, 0x41:
+		return uint32(c >> 16) // & 0xffffffff
+	}
+	return 0
+}
+
+// local returns the local administrator sub-field. It may be 2 bytes or
+// 4 bytes depending on the value in the type field. If the length cannot be
+// determined, a value of zero is returned.
+func (c ExtendedCommunity) local() uint32 {
+	switch c.type_() {
+	case 0x00, 0x40:
+		return uint32(c) // & 0xffffffff
+	case 0x01, 0x02, 0x41:
+		return uint32(c) & 0xffff
+	}
+	return 0
+}
+
+// String returns a human-readable string. The format is subject to change.
+func (c ExtendedCommunity) String() string {
+	switch c.subType() {
+	case 0x02:
+		switch c.type_() {
+		case 0x00, 0x02:
+			return fmt.Sprintf("rt:%v:%v", c.global(), c.local())
+		}
+	case 0x03:
+		switch c.type_() {
+		case 0x00, 0x02:
+			return fmt.Sprintf("soo:%v:%v", c.global(), c.local())
+		}
+	}
+	return fmt.Sprintf("%016x", uint64(c))
+}


### PR DESCRIPTION
This is incomplete and subject to change. Extended communities are uncommon in the global routing table, but some providers use them for traffic engineering. This change provides the bare minimum needed to receive or announce them.