### PR TITLE
Document the need to disable multipath TCP when using MD5 auth

### DIFF
--- a/bgp/server_test.go
+++ b/bgp/server_test.go
@@ -15,6 +15,7 @@
 package bgp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -241,6 +242,7 @@ func TestServer(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc := tc
 			t.Parallel()
+			ctx := context.Background()
 
 			loopback := netip.MustParseAddr(tc.Loopback)
 
@@ -254,12 +256,14 @@ func TestServer(t *testing.T) {
 			tc.RightServer.Logger = rightLogger
 
 			// Start two listeners on any available ports.
+			cfg := &net.ListenConfig{}
+			cfg.SetMultipathTCP(false)
 			lisAddr := netip.AddrPortFrom(loopback, 0).String()
-			leftListener, err := net.Listen("tcp", lisAddr)
+			leftListener, err := cfg.Listen(ctx, "tcp", lisAddr)
 			if err != nil {
 				t.Fatalf("L: failed to listen: %v", err)
 			}
-			rightListener, err := net.Listen("tcp", lisAddr)
+			rightListener, err := cfg.Listen(ctx, "tcp", lisAddr)
 			if err != nil {
 				t.Fatalf("R: failed to listen: %v", err)
 			}

--- a/third_party/tcpmd5/tcpmd5.go
+++ b/third_party/tcpmd5/tcpmd5.go
@@ -66,6 +66,10 @@ func DialerControl(password string) func(_, _ string, _ syscall.RawConn) error {
 
 // ConfigureListener returns a function that enables TCP MD5 signatures for
 // connections accepted from the specified address.
+//
+// TCP MD5 signatures are incompatible with multipath TCP, which is enabled by
+// default in Go 1.24. To disable TCP multipath, see
+// https://pkg.go.dev/net#ListenConfig.SetMultipathTCP.
 func ConfigureListener(address, password string) func(_ net.Listener) error {
 	t := tcpMD5Sig(address, password)
 	return func(lis net.Listener) error {


### PR DESCRIPTION
Listening sockets in Go 1.24 have multipath TCP enabled by default, which is incompatible with TCP MD5 signatures. Listeners are created by the user, so the best we can do is document the incompatibility and provide instructions.

Also disable multipath TCP in tests so they pass with Go 1.24.