### PR TITLE
Support structured logging instead of text logging

### DIFF
--- a/bgp/peer.go
+++ b/bgp/peer.go
@@ -15,6 +15,7 @@
 package bgp
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/netip"
@@ -159,7 +160,7 @@ func (p *Peer) start(s *Server) error {
 		stopC:        make(chan struct{}),
 		doneC:        make(chan struct{}),
 	}
-	go p.fsm.run(p)
+	go p.fsm.run(context.Background(), p)
 	return nil
 }
 


### PR DESCRIPTION
This greatly increases the user's control over what gets logged and how it's formatted. Peer events such as session setup and teardown are logged at INFO and ERROR levels. Session events like BGP announcements and withdrawals are logged at a locally defined LevelUpdates that falls between DEBUG and INFO.

This is a breaking change for anyone who enabled logging, but the simple fix is to just pass slog.Default() instead of log.Default(). The output will be formatted differently and will not print individual BGP announcements by default. But that's of course configurable by providing a custom slog.Handler.